### PR TITLE
Add -rf64 option

### DIFF
--- a/acsuite/__init__.py
+++ b/acsuite/__init__.py
@@ -113,7 +113,7 @@ def eztrim(clip: vs.VideoNode,
             audio_file_ext = '.wav'
             codec_args = []
         else:
-            codec_args = ['-c:a', 'copy']
+            codec_args = ['-c:a', 'copy', '-rf64', 'auto']
 
         if outfile is None:
             outfile = audio_file_name + '_cut' + audio_file_ext

--- a/acsuite/__init__.py
+++ b/acsuite/__init__.py
@@ -105,7 +105,7 @@ def eztrim(clip: vs.VideoNode,
             '.sbc',
             '.thd',
             '.tta',
-            '.wav',
+            '.wav', 'w64',
             '.wma',
         }
         if audio_file_ext not in ffmpeg_valid_encoder_extensions:


### PR DESCRIPTION
It allows wav file > 4BG.
I find this option by chance and it should work with any format since it is set on `auto`.

This way, we can add the .w64 extension.